### PR TITLE
Feat: Expression overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea/**
-build/**
+**/build/**
 build-coverage/**
 cmake*/**
 CMakeFiles*/**

--- a/Examples/fibonacci.tree
+++ b/Examples/fibonacci.tree
@@ -1,11 +1,11 @@
-ui64 fibonacci(ui8 n) {
-	if (n <= 1) return 1;
+ui64 fibonacci(ui64 n) {
+	if n <= 1 { return 1; }
 	return fibonacci(n - 2) + fibonacci(n - 1);
 }
 
 i32 main(string[] argv) {
 	ui64 fibo = fibonacci(10);
 	#assert(fibo == 89);
-	stdout.write(fibo);
+	stdout.writeln(fibo);
 	return 0;
 }

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The syntax of the language itself
 ### I/O
 - Console:
     - Writing: `stdout.write("text here")` or `stdout.writeln("Text here")` for automatic line breaks
-    - Reading: `stdin.read()` or `stdin.readline()`. `read()` returns a ui32 and `readline()` returns a ui32[] of the bytes that were read (UTF-8 encoding)
+    - Reading: `stdin.read()` or `stdin.readln()`. `read()` returns a ui32 and `readln()` returns a ui32[] of the bytes that were read (UTF-8 encoding)
 - Filesystem: 
     - Writing: `fs.write(path, bytes)`
     - Reading: `ui8[] fs.read(path)`

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The syntax of the language itself
 ### Operators
 - Assignment: `=`
 - Comparison: `==` (everything compared by value, for reference checking you have get reference first: `\string1 == \string2`)
-- Arithmetic: `+, -, /, *, %, ** (power of)` (arithmetic and assignment can be combined)
-- Boolean logic: `|, ||, &, &&, ^ (xor), ! (not), >, <, <=, >=`
+- Arithmetic: `+, -, /, *, %, ** (power of), ~ (numerical not)` (arithmetic and assignment can be combined)
+- Boolean logic: `|, ||, &, &&, ^ (xor), ! (logical not), >, <, <=, >=`
 - References: `\ (get address), @ (dereference)`
 - Calling operator: `.`
 

--- a/Source/Parser/Expression.cpp
+++ b/Source/Parser/Expression.cpp
@@ -3,153 +3,154 @@
 namespace forest::parser {
 
 	Expression::~Expression() {
-		delete mLeft;
-		delete mRight;
+		for (const auto& exp : mChildren) {
+			delete exp;
+		}
+		mChildren.clear();
 	}
 
 
 	Expression::Expression() {
 		mValue = {};
-		mLeft = nullptr;
-		mRight = nullptr;
+		mChildren = {};
 	}
 
 	Expression::Expression(const Expression& rhs) {
 		mValue = rhs.mValue;
-		if (rhs.mLeft != nullptr)
-			mLeft = new Expression(*rhs.mLeft);
-		else
-			mLeft = nullptr;
-		if (rhs.mRight != nullptr)
-			mRight = new Expression(*rhs.mRight);
-		else
-			mRight = nullptr;
+		for (const auto& exp : rhs.mChildren) {
+			Expression* newExp = new Expression(*exp);
+			mChildren.push_back(newExp);
+		}
 	}
 
 	void Expression::Collapse() {
-		if (mLeft == nullptr && mRight == nullptr) {
-			return;
-		}
-		if (mValue.mType != TokenType::OPERATOR) {
+		if (mChildren.empty()) {
 			return;
 		}
 
-		mLeft->Collapse();
-		mRight->Collapse();
-		if (mLeft->mValue.mType != TokenType::LITERAL || mRight->mValue.mType != TokenType::LITERAL) {
+		if (mValue.mType != TokenType::OPERATOR ) {
+			return;
+		}
+
+		Expression* leftExp = mChildren[0];
+		Expression* rightExp = mChildren[1];
+
+		leftExp->Collapse();
+		rightExp->Collapse();
+		if (leftExp->mValue.mType != TokenType::LITERAL || rightExp->mValue.mType != TokenType::LITERAL) {
 			return;
 		}
 
 		if (mValue.mText == "-") {
-			if (mLeft->mValue.mSubType == TokenSubType::STRING_LITERAL || mRight->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
-			if (mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL && mRight->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
-				int64_t left = std::stol(mLeft->mValue.mText);
-				int64_t right = std::stol(mRight->mValue.mText);
+			if (leftExp->mValue.mSubType == TokenSubType::STRING_LITERAL || rightExp->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
+			if (leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL && rightExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
+				int64_t left = std::stol(leftExp->mValue.mText);
+				int64_t right = std::stol(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::INTEGER_LITERAL;
 				mValue.mText = std::to_string(left - right);
-			} else if (mLeft->mValue.mSubType == TokenSubType::FLOAT_LITERAL || mRight->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
-				double left = std::stod(mLeft->mValue.mText);
-				double right = std::stod(mRight->mValue.mText);
+			} else if (leftExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL || rightExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
+				double left = std::stod(leftExp->mValue.mText);
+				double right = std::stod(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::FLOAT_LITERAL;
 				mValue.mText = std::to_string(left - right);
 			}
 		} else if (mValue.mText == "+") {
-			if (mLeft->mValue.mSubType == TokenSubType::STRING_LITERAL || mRight->mValue.mSubType == TokenSubType::STRING_LITERAL) {
+			if (leftExp->mValue.mSubType == TokenSubType::STRING_LITERAL || rightExp->mValue.mSubType == TokenSubType::STRING_LITERAL) {
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::STRING_LITERAL;
-				mValue.mText = mLeft->mValue.mText + mRight->mValue.mText;
-			} else if (mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL && mRight->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
-				int64_t left = std::stol(mLeft->mValue.mText);
-				int64_t right = std::stol(mRight->mValue.mText);
+				mValue.mText = leftExp->mValue.mText + rightExp->mValue.mText;
+			} else if (leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL && rightExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
+				int64_t left = std::stol(leftExp->mValue.mText);
+				int64_t right = std::stol(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::INTEGER_LITERAL;
 				mValue.mText = std::to_string(left + right);
-			} else if (mLeft->mValue.mSubType == TokenSubType::FLOAT_LITERAL || mRight->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
-				double left = std::stod(mLeft->mValue.mText);
-				double right = std::stod(mRight->mValue.mText);
+			} else if (leftExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL || rightExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
+				double left = std::stod(leftExp->mValue.mText);
+				double right = std::stod(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::FLOAT_LITERAL;
 				mValue.mText = std::to_string(left + right);
 			}
 		} else if (mValue.mText == "/") {
-			if (mLeft->mValue.mSubType == TokenSubType::STRING_LITERAL || mRight->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
-			if (mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL && mRight->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
-				int64_t left = std::stol(mLeft->mValue.mText);
-				int64_t right = std::stol(mRight->mValue.mText);
+			if (leftExp->mValue.mSubType == TokenSubType::STRING_LITERAL || rightExp->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
+			if (leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL && rightExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
+				int64_t left = std::stol(leftExp->mValue.mText);
+				int64_t right = std::stol(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::INTEGER_LITERAL;
 				mValue.mText = std::to_string(left / right);
-			} else if (mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL && mRight->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
-				int64_t left = std::stol(mLeft->mValue.mText);
-				double right = std::stod(mRight->mValue.mText);
+			} else if (leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL && rightExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
+				int64_t left = std::stol(leftExp->mValue.mText);
+				double right = std::stod(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::FLOAT_LITERAL;
 				mValue.mText = std::to_string(left / right);
-			} else if (mLeft->mValue.mSubType == TokenSubType::FLOAT_LITERAL && mRight->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
-				double left = std::stod(mLeft->mValue.mText);
-				int64_t right = std::stol(mRight->mValue.mText);
+			} else if (leftExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL && rightExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
+				double left = std::stod(leftExp->mValue.mText);
+				int64_t right = std::stol(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::INTEGER_LITERAL;
 				mValue.mText = std::to_string(left / right);
-			} else if (mLeft->mValue.mSubType == TokenSubType::FLOAT_LITERAL && mRight->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
-				double left = std::stod(mLeft->mValue.mText);
-				double right = std::stod(mRight->mValue.mText);
+			} else if (leftExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL && rightExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
+				double left = std::stod(leftExp->mValue.mText);
+				double right = std::stod(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::FLOAT_LITERAL;
 				mValue.mText = std::to_string(left / right);
 			}
 		} else if (mValue.mText == "*") {
-			if (mLeft->mValue.mSubType == TokenSubType::STRING_LITERAL && mRight->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
-			if (mLeft->mValue.mSubType == TokenSubType::STRING_LITERAL || mRight->mValue.mSubType == TokenSubType::STRING_LITERAL) {
-				if (!(mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL || mRight->mValue.mSubType == TokenSubType::INTEGER_LITERAL)) return;
+			if (leftExp->mValue.mSubType == TokenSubType::STRING_LITERAL && rightExp->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
+			if (leftExp->mValue.mSubType == TokenSubType::STRING_LITERAL || rightExp->mValue.mSubType == TokenSubType::STRING_LITERAL) {
+				if (!(leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL || rightExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL)) return;
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::STRING_LITERAL;
 
-				if (mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
-					int64_t left = std::stol(mLeft->mValue.mText);
+				if (leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
+					int64_t left = std::stol(leftExp->mValue.mText);
 					mValue.mText = "";
 					for (int i = 0; i < left; i++) {
-						mValue.mText += mRight->mValue.mText;
+						mValue.mText += rightExp->mValue.mText;
 					}
 				} else {
-					int64_t right = std::stol(mRight->mValue.mText);
+					int64_t right = std::stol(rightExp->mValue.mText);
 					mValue.mText = "";
 					for (int i = 0; i < right; i++) {
-						mValue.mText += mLeft->mValue.mText;
+						mValue.mText += leftExp->mValue.mText;
 					}
 				}
-			} else if (mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL && mRight->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
-				int64_t left = std::stol(mLeft->mValue.mText);
-				int64_t right = std::stol(mRight->mValue.mText);
+			} else if (leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL && rightExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
+				int64_t left = std::stol(leftExp->mValue.mText);
+				int64_t right = std::stol(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::INTEGER_LITERAL;
 				mValue.mText = std::to_string(left * right);
-			} else if (mLeft->mValue.mSubType == TokenSubType::FLOAT_LITERAL || mRight->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
-				double left = std::stod(mLeft->mValue.mText);
-				double right = std::stod(mRight->mValue.mText);
+			} else if (leftExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL || rightExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL) {
+				double left = std::stod(leftExp->mValue.mText);
+				double right = std::stod(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::FLOAT_LITERAL;
 				mValue.mText = std::to_string(left * right);
 			}
 		} else if (mValue.mText == "%") {
-			if (mLeft->mValue.mSubType == TokenSubType::STRING_LITERAL || mRight->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
-			if (mLeft->mValue.mSubType == TokenSubType::FLOAT_LITERAL || mRight->mValue.mSubType == TokenSubType::FLOAT_LITERAL) return;
+			if (leftExp->mValue.mSubType == TokenSubType::STRING_LITERAL || rightExp->mValue.mSubType == TokenSubType::STRING_LITERAL) return;
+			if (leftExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL || rightExp->mValue.mSubType == TokenSubType::FLOAT_LITERAL) return;
 
-			if (mLeft->mValue.mSubType == TokenSubType::INTEGER_LITERAL && mRight->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
-				int64_t left = std::stol(mLeft->mValue.mText);
-				int64_t right = std::stol(mRight->mValue.mText);
+			if (leftExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL && rightExp->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
+				int64_t left = std::stol(leftExp->mValue.mText);
+				int64_t right = std::stol(rightExp->mValue.mText);
 
 				mValue.mType = TokenType::LITERAL;
 				mValue.mSubType = TokenSubType::INTEGER_LITERAL;
@@ -157,14 +158,10 @@ namespace forest::parser {
 			}
 		}
 
-		if (mLeft != nullptr) {
-			delete mLeft;
-			mLeft = nullptr;
-		}
-		if (mRight != nullptr) {
-			delete mRight;
-			mRight = nullptr;
-		}
+		delete leftExp;
+		mChildren[0] = nullptr;
+		delete rightExp;
+		mChildren[1] = nullptr;
 	}
 
 

--- a/Source/Parser/Expression.hpp
+++ b/Source/Parser/Expression.hpp
@@ -7,8 +7,7 @@ namespace forest::parser {
 
 	class Expression {
 	public:
-		Expression* mLeft = nullptr;
-		Expression* mRight = nullptr;
+		std::vector<Expression*> mChildren;
 		Token mValue {};
 
 		~Expression();

--- a/Source/Parser/Parser.cpp
+++ b/Source/Parser/Parser.cpp
@@ -863,8 +863,8 @@ namespace forest::parser {
 					nameNode->mValue.mText = v.mName;
 					Expression* opNode = new Expression;
 					opNode->mValue = op;
-					opNode->mLeft = nameNode;
-					opNode->mRight = expression;
+					opNode->mChildren.push_back(nameNode);
+					opNode->mChildren.push_back(expression);
 					values.push_back(opNode);
 				} else {
 					values.push_back(expression);
@@ -1108,8 +1108,8 @@ namespace forest::parser {
 						return nullptr;
 					}
 
-					op->mLeft = left;
-					op->mRight = right;
+					op->mChildren.push_back(left);
+					op->mChildren.push_back(right);
 					nodes.push_back(op);
 				}
 			} else if (mCurrentToken->mType == TokenType::IDENTIFIER) {
@@ -1130,8 +1130,8 @@ namespace forest::parser {
 					left->mValue = identifier.value();
 					Expression* right = expectExpression(newStatement);
 					expectOperator("]"); // We discard this value because we don't need it
-					node->mLeft = left;
-					node->mRight = right;
+					node->mChildren.push_back(left);
+					node->mChildren.push_back(right);
 					nodes.push_back(node);
 				} else if (nextToken.has_value() && nextToken.value().mText == "(") {
 					// Can only be function call, would be regular operator if this is meant to be a variable
@@ -1144,10 +1144,14 @@ namespace forest::parser {
 					node->mValue = funcCall.value();
 					Expression* left = new Expression;
 					left->mValue = identifier.value();
+
+					// While nodes.back.mValue startswith ':' or '.' , popback op, popback identifier
+					// This gives us namespace::class.e:function(
+					// While operator ')' is nothing, and comma exists, expect expression (Look at funcCall parsing)
 					Expression* right = expectExpression(newStatement);
 					expectOperator(")"); // We discard this value because we don't need it
-					node->mLeft = left;
-					node->mRight = right;
+					node->mChildren.push_back(left);
+					node->mChildren.push_back(right);
 					nodes.push_back(node);
 				} else {
 					Expression* node = new Expression;
@@ -1182,8 +1186,8 @@ namespace forest::parser {
 				return nullptr;
 			}
 
-			op->mLeft = left;
-			op->mRight = right;
+			op->mChildren.push_back(left);
+			op->mChildren.push_back(right);
 			nodes.push_back(op);
 		}
 

--- a/Source/Tests/ParserTests.cpp
+++ b/Source/Tests/ParserTests.cpp
@@ -208,21 +208,21 @@ TEST_F(ParserTests, ParserTryParseExpression4Minus3Plus1) {
 	EXPECT_EQ(expression->mValue.mType, TokenType::OPERATOR);
 	EXPECT_STREQ(expression->mValue.mText.c_str(), "+");
 
-	Token left = expression->mLeft->mValue;
+	Token left = expression->mChildren[0]->mValue;
 	EXPECT_EQ(left.mType, TokenType::OPERATOR);
 	EXPECT_STREQ(left.mText.c_str(), "-");
 
-	Token leftleft = expression->mLeft->mLeft->mValue;
+	Token leftleft = expression->mChildren[0]->mChildren[0]->mValue;
 	EXPECT_EQ(leftleft.mType, TokenType::LITERAL);
 	EXPECT_EQ(leftleft.mSubType, TokenSubType::INTEGER_LITERAL);
 	EXPECT_STREQ(leftleft.mText.c_str(), "4");
 
-	Token leftright = expression->mLeft->mRight->mValue;
+	Token leftright = expression->mChildren[0]->mChildren[1]->mValue;
 	EXPECT_EQ(leftright.mType, TokenType::LITERAL);
 	EXPECT_EQ(leftright.mSubType, TokenSubType::INTEGER_LITERAL);
 	EXPECT_STREQ(leftright.mText.c_str(), "3");
 
-	Token right = expression->mRight->mValue;
+	Token right = expression->mChildren[1]->mValue;
 	EXPECT_EQ(right.mType, TokenType::LITERAL);
 	EXPECT_EQ(right.mSubType, TokenSubType::INTEGER_LITERAL);
 	EXPECT_STREQ(right.mText.c_str(), "1");
@@ -244,21 +244,21 @@ TEST_F(ParserTests, ParserTryParseExpression4Minus3Plus1V2) {
 	EXPECT_EQ(expression->mValue.mType, TokenType::OPERATOR);
 	EXPECT_STREQ(expression->mValue.mText.c_str(), "-");
 
-	Token left = expression->mLeft->mValue;
+	Token left = expression->mChildren[0]->mValue;
 	EXPECT_EQ(left.mType, TokenType::LITERAL);
 	EXPECT_EQ(left.mSubType, TokenSubType::INTEGER_LITERAL);
 	EXPECT_STREQ(left.mText.c_str(), "4");
 
-	Token right = expression->mRight->mValue;
+	Token right = expression->mChildren[1]->mValue;
 	EXPECT_EQ(right.mType, TokenType::OPERATOR);
 	EXPECT_STREQ(right.mText.c_str(), "+");
 
-	Token rightleft = expression->mRight->mLeft->mValue;
+	Token rightleft = expression->mChildren[1]->mChildren[0]->mValue;
 	EXPECT_EQ(rightleft.mType, TokenType::LITERAL);
 	EXPECT_EQ(rightleft.mSubType, TokenSubType::INTEGER_LITERAL);
 	EXPECT_STREQ(rightleft.mText.c_str(), "3");
 
-	Token rightright = expression->mRight->mRight->mValue;
+	Token rightright = expression->mChildren[1]->mChildren[1]->mValue;
 	EXPECT_EQ(rightright.mType, TokenType::LITERAL);
 	EXPECT_EQ(rightright.mSubType, TokenSubType::INTEGER_LITERAL);
 	EXPECT_STREQ(rightright.mText.c_str(), "1");
@@ -279,8 +279,8 @@ TEST_F(ParserTests, ParserExpressionCollapse4Minus1) {
 	expression->Collapse();
 
 	ASSERT_NE(expression, nullptr);
-	ASSERT_EQ(expression->mLeft, nullptr);
-	ASSERT_EQ(expression->mRight, nullptr);
+	ASSERT_EQ(expression->mChildren[0], nullptr);
+	ASSERT_EQ(expression->mChildren[1], nullptr);
 
 	EXPECT_EQ(expression->mValue.mType, TokenType::LITERAL);
 	EXPECT_EQ(expression->mValue.mSubType, TokenSubType::INTEGER_LITERAL);
@@ -299,8 +299,8 @@ TEST_F(ParserTests, ParserExpressionCollapse4Minus3Plus1) {
 	expression->Collapse();
 
 	ASSERT_NE(expression, nullptr);
-	ASSERT_EQ(expression->mLeft, nullptr);
-	ASSERT_EQ(expression->mRight, nullptr);
+	ASSERT_EQ(expression->mChildren[0], nullptr);
+	ASSERT_EQ(expression->mChildren[1], nullptr);
 
 	EXPECT_EQ(expression->mValue.mType, TokenType::LITERAL);
 	EXPECT_EQ(expression->mValue.mSubType, TokenSubType::INTEGER_LITERAL);
@@ -319,8 +319,8 @@ TEST_F(ParserTests, ParserExpressionCollapse4Modulo3) {
 	expression->Collapse();
 
 	ASSERT_NE(expression, nullptr);
-	ASSERT_EQ(expression->mLeft, nullptr);
-	ASSERT_EQ(expression->mRight, nullptr);
+	ASSERT_EQ(expression->mChildren[0], nullptr);
+	ASSERT_EQ(expression->mChildren[1], nullptr);
 
 	EXPECT_EQ(expression->mValue.mType, TokenType::LITERAL);
 	EXPECT_EQ(expression->mValue.mSubType, TokenSubType::INTEGER_LITERAL);
@@ -339,8 +339,8 @@ TEST_F(ParserTests, ParserExpressionCollapse3TimesString) {
 	expression->Collapse();
 
 	ASSERT_NE(expression, nullptr);
-	ASSERT_EQ(expression->mLeft, nullptr);
-	ASSERT_EQ(expression->mRight, nullptr);
+	ASSERT_EQ(expression->mChildren[0], nullptr);
+	ASSERT_EQ(expression->mChildren[1], nullptr);
 
 	EXPECT_EQ(expression->mValue.mType, TokenType::LITERAL);
 	EXPECT_EQ(expression->mValue.mSubType, TokenSubType::STRING_LITERAL);

--- a/Source/Tests/TokeniserTests.cpp
+++ b/Source/Tests/TokeniserTests.cpp
@@ -75,10 +75,31 @@ TEST_F(TokeniserTests, TokeniserParseShouldTokeniseFloatLiterals) {
 }
 
 TEST_F(TokeniserTests, TokeniserParseShouldTokeniseAssignmentOperators) {
-	std::string code = "+= -= *= /= %= >>= <<= |= &= ^= != **=";
+	std::string code = "+= -= *= /= %= >>= <<= |= &= ^= != ~= **=";
 	std::vector<Token> tokens = forest::parser::Tokeniser::parse(code, filePath);
 
-	ASSERT_EQ(tokens.size(), 12);
+	ASSERT_EQ(tokens.size(), 13);
+
+	size_t pos = 0;
+	std::string op;
+	std::string delim = " ";
+	int i = 0;
+	while ((pos = code.find(delim)) != std::string::npos) {
+		op = code.substr(0, pos);
+		Token token = tokens[i];
+		EXPECT_EQ(token.mType, TokenType::OPERATOR);
+		EXPECT_STREQ(token.mText.c_str(), op.c_str());
+		i++;
+		code.erase(0, pos + delim.length());
+	}
+
+}
+
+TEST_F(TokeniserTests, TokeniserParseShouldTokeniseOperators) {
+	std::string code = "+ ++ - -- * ** / ( ) | || & && % >> << ^ ! ~";
+	std::vector<Token> tokens = forest::parser::Tokeniser::parse(code, filePath);
+
+	ASSERT_EQ(tokens.size(), 19);
 
 	size_t pos = 0;
 	std::string op;
@@ -168,6 +189,17 @@ TEST_F(TokeniserTests, TokeniserEndTokenShouldConvertSubtypes) {
 	EXPECT_EQ(skipToken.mType, TokenType::IDENTIFIER);
 	EXPECT_EQ(skipToken.mSubType, TokenSubType::SKIP);
 	EXPECT_STREQ(skipToken.mText.c_str(), "skip");
+
+	token.mType = TokenType::IDENTIFIER;
+	token.mText = "true";
+
+	forest::parser::Tokeniser::endToken(token, tokens);
+	ASSERT_EQ(tokens.size(), 3);
+
+	Token trueToken = tokens[2];
+	EXPECT_EQ(trueToken.mType, TokenType::LITERAL);
+	EXPECT_EQ(trueToken.mSubType, TokenSubType::BOOLEAN_LITERAL);
+	EXPECT_STREQ(trueToken.mText.c_str(), "1");
 }
 
 TEST(TokenTests, TokenGetTypeShouldReturnType) {
@@ -198,4 +230,12 @@ TEST(TokenTests, TokenGetTypeShouldReturnType) {
 
 	token.mType = TokenType::STRING_ESCAPE_SEQUENCE;
 	EXPECT_STREQ(token.getType(), "STRING_ESCAPE_SEQUENCE");
+}
+
+TEST(TokenTests, TokenToLowerShouldBeLowered) {
+	Token token;
+	token.mText = "TRUE";
+
+	EXPECT_STREQ(token.toLower().c_str(), "true");
+
 }

--- a/Source/Tokeniser/Tokeniser.hpp
+++ b/Source/Tokeniser/Tokeniser.hpp
@@ -26,11 +26,14 @@ namespace forest::parser {
 		FLOAT_LITERAL,
 		STRING_LITERAL,
 		CHAR_LITERAL,
+		BOOLEAN_LITERAL,
 
 		// Maybe operator subtypes too
 		DOT,
 		RANGE,
 		NAMESPACE,
+		OP_UNARY,
+		OP_BINARY,
 
 		// Keyword Identifiers
 		RETURN,
@@ -59,9 +62,12 @@ namespace forest::parser {
 		"FLOAT_LITERAL",
 		"STRING_LITERAL",
 		"CHAR_LITERAL",
+		"BOOLEAN_LITERAL",
 		"DOT",
 		"RANGE",
 		"NAMESPACE",
+		"OP_UNARY",
+		"OP_BINARY",
 		"RETURN",
 		"BREAK",
 		"SKIP",
@@ -82,6 +88,7 @@ namespace forest::parser {
 
 		void debugPrint() const;
 		const char* getType() const;
+		std::string toLower() const;
 		friend std::ostream& operator<<(std::ostream&, const Token&);
 	};
 

--- a/Source/X86_64LinuxYasmCompiler.cpp
+++ b/Source/X86_64LinuxYasmCompiler.cpp
@@ -93,7 +93,7 @@ void X86_64LinuxYasmCompiler::compile(fs::path& filePath, const Programme& p) {
 	// For every variable, keep track of the offset
 	// End with epilogue 'pop rbp'
 
-	const char callingConvention[6][4] = {"rdi", "rsi", "rdx", "rcx", "r8", "r9"};
+	const char callingConvention[6][4] = {"di", "si", "d", "c", "8", "9"};
 
 	for (const auto& function : p.functions) {
 		if (function.mName == "main") {
@@ -120,7 +120,7 @@ void X86_64LinuxYasmCompiler::compile(fs::path& filePath, const Programme& p) {
 		} else {
 			for (size_t i = 0; i < function.mArgs.size(); i++) {
 				const auto& arg = function.mArgs[i];
-				std::string reg = i < 6 ? callingConvention[i] : "rbp+";
+				std::string reg = i < 6 ? getRegister(callingConvention[i], getSizeFromByteSize(arg.mType.byteSize)) : "rbp+";
 
 				addToSymbols(&argOffset, Variable{arg.mType, arg.mName, {}}, reg);
 			}
@@ -129,6 +129,7 @@ void X86_64LinuxYasmCompiler::compile(fs::path& filePath, const Programme& p) {
 		printBody(outfile, p, function.mBody, function.mName, &offset);
 
 		if (function.mName != "main") {
+			outfile << ".exit:" << std::endl;
 			outfile << "; =============== EPILOGUE ===============" << std::endl;
 			outfile << "\tpop rbp" << std::endl;
 			outfile << "\tret" << std::endl;
@@ -244,7 +245,7 @@ void X86_64LinuxYasmCompiler::printFunctionCall(std::ofstream& outfile, const Pr
 
 	} else if (arg->mValue.mType == TokenType::LITERAL && arg->mValue.mSubType == TokenSubType::INTEGER_LITERAL) {
 		outfile << "; =============== FUNC CALL + INT ===============" << std::endl;
-		outfile << "\tmov edi, " << arg->mValue.mText << std::endl;
+		outfile << "\tmov rdi, " << arg->mValue.mText << std::endl;
 		if (fc.mFunctionName == "write") {
 			outfile << "\tcall print_uint32" << std::endl;
 		} else if (fc.mFunctionName == "writeln") {
@@ -255,7 +256,8 @@ void X86_64LinuxYasmCompiler::printFunctionCall(std::ofstream& outfile, const Pr
 	} else if (arg->mValue.mType == TokenType::IDENTIFIER) {
 		SymbolInfo& var = symbolTable[arg->mValue.mText];
 		outfile << "; =============== FUNC CALL + VARIABLE ===============" << std::endl;
-		outfile << "\tmovzx edi, " << sizes[var.size] << " " << var.location() << std::endl;
+		const char* moveAction = getMoveAction(3, var.size, false);
+		outfile << "\t" << moveAction << " rdi, " << sizes[var.size] << " " << var.location() << std::endl;
 		if (fc.mFunctionName == "write") {
 			outfile << "\tcall print_uint32" << std::endl;
 		} else if (fc.mFunctionName == "writeln") {
@@ -301,7 +303,7 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					outfile << "\tmov rax, 60" << std::endl;
 					outfile << "\tsyscall" << std::endl;
 				} else {
-					outfile << "\tret" << std::endl;
+					outfile << "\tjmp .exit" << std::endl;
 				}
 				break;
 			case Statement_Type::VAR_DECLARATION:
@@ -394,32 +396,32 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					int size = addToSymbols(offset, ls.mIterator.value());
 					addToSymbols(&localOffset, ls.mIterator.value());
 					std::string op = ls.mRange.value().mMinimum < ls.mRange.value().mMaximum ? "inc " : "dec ";
-					std::string label = "label";
+					std::string label = ".label";
 					uint32_t localLabelCount = ++labelCount;
 					label = label.append(std::to_string(localLabelCount));
 					recentLoopLabel = label;
 					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", " << ls.mRange.value().mMinimum->mValue.mText << std::endl;
 					outfile << label << ":" << std::endl;
 					outfile << "\tcmp " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", " << ls.mRange.value().mMaximum->mValue.mText << std::endl;
-					outfile << "\tjne inside_label" << localLabelCount << std::endl;
-					outfile << "\tjmp not_label" << localLabelCount << std::endl;
-					outfile << "inside_label" << localLabelCount << ":" << std::endl;
+					outfile << "\tjne .inside_label" << localLabelCount << std::endl;
+					outfile << "\tjmp .not_label" << localLabelCount << std::endl;
+					outfile << ".inside_label" << localLabelCount << ":" << std::endl;
 					printBody(outfile, p, ls.mBody, label, offset);
-					outfile << "skip_label" << localLabelCount << ":" << std::endl;
+					outfile << ".skip_label" << localLabelCount << ":" << std::endl;
 					outfile << "\t" << moveToRegister("rax", symbolTable[ls.mIterator.value().mName]).str();
 					outfile << "\t" << op << "rax" << std::endl;
 					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", al" << std::endl;
-					outfile << "\tjmp label" << localLabelCount << std::endl;
-					outfile << "not_label" << localLabelCount << ":" << std::endl;
+					outfile << "\tjmp .label" << localLabelCount << std::endl;
+					outfile << ".not_label" << localLabelCount << ":" << std::endl;
 				} else {
 					if (statement.mContent == nullptr) {
 						// We have "loop { ... }"
-						std::string label = "label";
+						std::string label = ".label";
 						label = label.append(std::to_string(++labelCount));
 						outfile << label << ":" << std::endl;
 						printBody(outfile, p, ls.mBody, label, offset);
-						outfile << "\tjmp label" << labelCount << std::endl;
-						outfile << "not_label" << labelCount << ":" << std::endl; // Used for break statements
+						outfile << "\tjmp .label" << labelCount << std::endl;
+						outfile << ".not_label" << labelCount << ":" << std::endl; // Used for break statements
 					} else {
 						// we have "until condition { ... }"
 					}
@@ -428,11 +430,11 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 			}
 			case Statement_Type::BREAK:
 				if (!recentLoopLabel.empty())
-					outfile << "\tjmp not_" << recentLoopLabel << std::endl;
+					outfile << "\tjmp .not_" << recentLoopLabel << std::endl;
 				break;
 			case Statement_Type::SKIP:
 				if (!recentLoopLabel.empty())
-					outfile << "\tjmp skip_" << recentLoopLabel << std::endl;
+					outfile << "\tjmp .skip_" << recentLoopLabel << std::endl;
 				break;
 			case Statement_Type::FUNC_CALL: {
 				FuncCallStatement fc = statement.funcCall.value();
@@ -444,6 +446,7 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					outfile << "\tpush rcx" << std::endl;
 					outfile << "\tpush r8" << std::endl;
 					outfile << "\tpush r9" << std::endl;
+					outfile << "\tpush r10" << std::endl;
 				}
 				if (fc.mClassName == "stdout" || fc.mClassName == "stdin") {
 					printFunctionCall(outfile, p, fc);
@@ -468,6 +471,7 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					outfile << "\tcall " << statement.funcCall.value().mFunctionName << std::endl;
 				}
 				if (labelName != "main") {
+					outfile << "\tpop r10" << std::endl;
 					outfile << "\tpop r9" << std::endl;
 					outfile << "\tpop r8" << std::endl;
 					outfile << "\tpop rcx" << std::endl;
@@ -483,23 +487,23 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 			case Statement_Type::IF: {
 				IfStatement is = statement.ifStatement.value();
 				printExpression(outfile, p, statement.mContent, 0);
-				std::string label = "if";
+				std::string label = ".if";
 				uint32_t localIfCount = ++ifCount;
 				label = label.append(std::to_string(localIfCount));
 				outfile << "\ttest rax, rax" << std::endl;
 				outfile << "\tjnz " << label << std::endl;
 				if (is.mElse.has_value())
-					outfile << "\tjmp else_if" <<  localIfCount << std::endl;
+					outfile << "\tjmp .else_if" <<  localIfCount << std::endl;
 				else
-					outfile << "\tjmp end_if" << localIfCount << std::endl;
+					outfile << "\tjmp .end_if" << localIfCount << std::endl;
 				outfile << label << ":" << std::endl;
 				printBody(outfile, p, is.mBody, label, offset);
-				outfile << "\tjmp end_if" << localIfCount << std::endl;
+				outfile << "\tjmp .end_if" << localIfCount << std::endl;
 				if (is.mElse.has_value()) {
-					outfile << "else_if" << localIfCount << ":" << std::endl;
+					outfile << ".else_if" << localIfCount << ":" << std::endl;
 					printBody(outfile, p, is.mElseBody.value(), label, offset);
 				}
-				outfile << "end_if" << localIfCount << ":" << std::endl;
+				outfile << ".end_if" << localIfCount << ":" << std::endl;
 				break;
 			}
 		}
@@ -638,6 +642,7 @@ ExpressionPrinted X86_64LinuxYasmCompiler::printExpression(std::ofstream& outfil
 				outfile << "\tpush rcx" << std::endl;
 				outfile << "\tpush r8" << std::endl;
 				outfile << "\tpush r9" << std::endl;
+				outfile << "\tpush r10" << std::endl;
 				std::string value;
 
 				if (child->mValue.mSubType == TokenSubType::STRING_LITERAL) {
@@ -656,6 +661,7 @@ ExpressionPrinted X86_64LinuxYasmCompiler::printExpression(std::ofstream& outfil
 				}
 				outfile << "\tcall " << ss.str() << std::endl;
 
+				outfile << "\tpop r10" << std::endl;
 				outfile << "\tpop r9" << std::endl;
 				outfile << "\tpop r8" << std::endl;
 				outfile << "\tpop rcx" << std::endl;
@@ -664,7 +670,7 @@ ExpressionPrinted X86_64LinuxYasmCompiler::printExpression(std::ofstream& outfil
 				outfile << "\tpop rdi" << std::endl;
 			}
 		}
-		return ExpressionPrinted{};
+		return ExpressionPrinted{ true, false, 3 };
 	} else if (expression->mValue.mSubType == TokenSubType::OP_UNARY) {
 		if (expression->mValue.mText == "\\") {
 			Expression* child = expression->mChildren[0];
@@ -813,6 +819,8 @@ ExpressionPrinted X86_64LinuxYasmCompiler::printExpression(std::ofstream& outfil
 		const char* reg = "rbx";//getRegister("b", size);
 		outfile << "\tmov " << reg << ", " << expression->mChildren[1]->mValue.mText << std::endl;
 	} else {
+		if (rightPrinted.printed)
+			outfile << "\tmov rbx, rax" << std::endl;
 		rightSize = rightPrinted.size;
 	}
 
@@ -831,9 +839,13 @@ ExpressionPrinted X86_64LinuxYasmCompiler::printExpression(std::ofstream& outfil
 		outfile << "\tadd " << r1 << ", " << r2 << std::endl;
 	} else if (expression->mValue.mText == "-") {
 		int size = getEvenSize(leftSize, rightSize);
-		std::string r1 = getRegister("a", size+1);
-		std::string r2 = getRegister("b", size+1);
-		outfile << "\tsbb " << r1 << ", " << r2 << std::endl;
+		if (size == 3)
+			outfile << "\tsub rax, rbx" << std::endl;
+		else {
+			std::string r1 = getRegister("a", size+1);
+			std::string r2 = getRegister("b", size+1);
+			outfile << "\tsbb " << r1 << ", " << r2 << std::endl;
+		}
 	} else if (expression->mValue.mText == "*") {
 		int size = getEvenSize(leftSize, rightSize);
 		std::string r2 = getRegister("b", size);

--- a/Source/X86_64LinuxYasmCompiler.hpp
+++ b/Source/X86_64LinuxYasmCompiler.hpp
@@ -37,7 +37,7 @@ struct ExpressionPrinted {
 
 class X86_64LinuxYasmCompiler {
 public:
-	void compile(fs::path& fileName, const Programme& p, const Function& main);
+	void compile(fs::path& filePath, const Programme& p);
 
 private:
 	uint32_t labelCount = 0;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -20,7 +20,6 @@ int main(int argc, char** argv) {
 	//fs::path filePath = argc == 1 || argc > 2 ? "../Examples/array-test.tree" : argv[1];
 	//fs::path filePath = argc == 1 || argc > 2 ? "../Examples/rule110.tree" : argv[1];
 	fs::path filePath = argc == 1 || argc > 2 ? "../Examples/controlflow-test.tree" : argv[1];
-	fs::path fileName = filePath.stem();
 
 	if (argc >= 2) {
 		// Run with arguments
@@ -57,7 +56,7 @@ int main(int argc, char** argv) {
 	}
 
 	X86_64LinuxYasmCompiler compiler;
-	compiler.compile(fileName, p, main);
+	compiler.compile(filePath, p);
 
 	return 0;
 }


### PR DESCRIPTION
This PR is to mainly fix the way we handled functions in the language before this. They were very simple with only one identifier and only one argument. Now, we allow for actual expression trees. 
We also added support for unary operators:

- `!` - Logical not -> Transforms a truthy value into a false and a falsy value into true.
- `~` - Numerical/Boolean not -> Flips all the bits of the value (0 becoming 1, 1 becoming 0)
- `\` - Reference operator -> Loads the address of the variable and returns a `ref<T>`
- `@` - Dereference operator -> Returns at the value that is referenced by the `ref<T>`