### PR TITLE
Feat: Added top level var support

### DIFF
--- a/Examples/Buffers/frstconfig
+++ b/Examples/Buffers/frstconfig
@@ -1,6 +1,6 @@
 [Configuration]
 BuildType = Debug
-Entrypoint = malloc.tree
+Entrypoint = main.tree
 
 [Conventions]
 pub fn = $SymbolName

--- a/Examples/Buffers/main.tree
+++ b/Examples/Buffers/main.tree
@@ -1,0 +1,9 @@
+ui8[100] s_buffer;
+
+i32 main(string[] argv) {
+	ui32 fd = SYS_OPEN("main.tree", 0, 0);
+	SYS_READ(fd, s_buffer, 100);
+	SYS_WRITE(1, s_buffer, 100);
+	SYS_WRITE(1, "\n", 1);
+	return fd;
+}

--- a/Examples/Multiple_Files/fileread.tree
+++ b/Examples/Multiple_Files/fileread.tree
@@ -1,0 +1,40 @@
+aligned struct Timespec {
+	i64 tv_sec;
+	i64 tv_nsec;
+};
+
+aligned struct FileMetadata {
+	ui64 device;
+	ui64 inode;
+	ui32 mode;
+	ui64 linkCount;
+	ui32 ownerUserID;
+	ui32 ownerGroupID;
+	ui64 specialFileDevice;
+	i64 size;
+	i64 blockSize;
+	i64 blockCount;
+	Timespec lastAccess;
+	Timespec lastModification;
+	Timespec lastStatusChange;
+};
+
+
+
+i32 main(string[] argv) {
+	FileMetadata meta;
+	bool useFile = true;
+	FileDescriptor fd = fs.open(argv[1]);
+	if (useFile) {
+		fd.getMetadata(\meta);
+	} else {
+		fs.getMetadata(argv[1], \meta);
+	}
+
+	ui8[meta.size] buffer; // Or heap allocated ref<ui8> buffer = new ui8[meta.size];
+	fd.read(meta.size, buffer);
+	string contents = string.fromBuffer(meta.size, buffer);
+	stdout.writeLine(contents);
+	fd.close();
+	return 0;
+}

--- a/Examples/range-test.tree
+++ b/Examples/range-test.tree
@@ -4,4 +4,5 @@ i32 main(string[] argv) {
 	loop i, start..end {
 		stdout.writeln(i);
 	}
+	return 0;
 }

--- a/Source/Parser/ConfigParser.cpp
+++ b/Source/Parser/ConfigParser.cpp
@@ -210,7 +210,6 @@ namespace forest::parser {
 
 			else if (modOrType.mText == "const") returnVal.modifiers |= Modifiers::CONSTANT;
 			else if (modOrType.mText == "static") returnVal.modifiers |= Modifiers::STATIC;
-			else if (modOrType.mText == "global") returnVal.modifiers |= Modifiers::GLOBAL;
 			else {
 				std::cerr << "Unexpected modifier or symbol type `" << modOrType.mText << "` while parsing conventions at " << modOrType << std::endl;
 				return std::nullopt;

--- a/Source/Parser/ConfigParser.hpp
+++ b/Source/Parser/ConfigParser.hpp
@@ -13,7 +13,6 @@ namespace forest::parser {
 		PROTECTED = 1 << 2,
 		CONSTANT  = 1 << 3,
 		STATIC    = 1 << 4,
-		GLOBAL    = 1 << 5,
 	};
 
 	inline Modifiers operator|(Modifiers lhs, Modifiers rhs) {

--- a/Source/Parser/Expression.cpp
+++ b/Source/Parser/Expression.cpp
@@ -35,8 +35,10 @@ namespace forest::parser {
 		Expression* leftExp = mChildren[0];
 		Expression* rightExp = mChildren[1];
 
-		leftExp->Collapse();
-		rightExp->Collapse();
+		if (leftExp != nullptr)
+			leftExp->Collapse();
+		if (rightExp != nullptr)
+			rightExp->Collapse();
 		if (leftExp->mValue.mType != TokenType::LITERAL || rightExp->mValue.mType != TokenType::LITERAL) {
 			return;
 		}

--- a/Source/Parser/Parser.cpp
+++ b/Source/Parser/Parser.cpp
@@ -61,7 +61,11 @@ namespace forest::parser {
 			} else {
 				std::optional<Function> f = expectFunction();
 				if (!f.has_value()) {
-					break;
+					std::optional<Statement> var = tryParseVariableDeclaration();
+					// Top level variable declaration
+					if (var.has_value()) {
+						variables.insert(std::make_pair(var.value().variable.value().mName, var.value().variable.value()));
+					}
 				} else {
 					//std::cout << "Successfully parsed function " << f->mName << std::endl;
 					functions.push_back(f.value());
@@ -75,7 +79,7 @@ namespace forest::parser {
 				externalFunctions.push_back(fc);
 			}
 		}
-		return Programme { functions, literals, externalFunctions, libDependencies, imports, requires_libs };
+		return Programme { functions, literals, externalFunctions, libDependencies, imports, variables, requires_libs };
 	}
 
 	std::optional<Token> Parser::peekNextToken() {

--- a/Source/Parser/Parser.cpp
+++ b/Source/Parser/Parser.cpp
@@ -986,7 +986,7 @@ namespace forest::parser {
 	Type Parser::getTypeFromRange(const Range& range) {
 		// TODO: We cannot know the types at compile time for some expressions
 		if (range.mMinimum->mValue.mSubType != TokenSubType::INTEGER_LITERAL)
-			return Type {"undefined", Builtin_Type::UNDEFINED, {}, 0, 0};
+			return Type {"i64", Builtin_Type::I64, {}, 4, 4}; // We take the default as something that will actually compile
 		if (range.mMaximum->mValue.mSubType != TokenSubType::INTEGER_LITERAL)
 			return Type {"undefined", Builtin_Type::UNDEFINED, {}, 0, 0};
 

--- a/Source/Parser/Parser.cpp
+++ b/Source/Parser/Parser.cpp
@@ -74,10 +74,12 @@ namespace forest::parser {
 		}
 
 		for (const auto& fc : _funcCalls) {
+			bool found = false;
 			for (const auto& f : functions) {
-				if (fc.mFunctionName == f.mName) continue;
-				externalFunctions.push_back(fc);
+				if (fc.mFunctionName == f.mName) found = true;
 			}
+			if (!found)
+				externalFunctions.push_back(fc);
 		}
 		return Programme { functions, literals, externalFunctions, libDependencies, imports, variables, requires_libs };
 	}

--- a/Source/Parser/Parser.hpp
+++ b/Source/Parser/Parser.hpp
@@ -199,6 +199,7 @@ namespace forest::parser {
 		std::vector<FuncCallStatement> externalFunctions;
 		std::vector<std::string> libDependencies;
 		std::vector<Import> imports;
+		std::map<std::string, Variable> variables;
 		bool requires_libs = false;
 
 		std::optional<Literal> findLiteralByAlias(const std::string& alias) const {

--- a/Source/Tests/TokeniserTests.cpp
+++ b/Source/Tests/TokeniserTests.cpp
@@ -138,6 +138,26 @@ TEST_F(TokeniserTests, TokeniserParseShouldTokeniseRange) {
 	EXPECT_STREQ(third.mText.c_str(), "4");
 }
 
+TEST_F(TokeniserTests, TokeniserParseShouldTokeniseRangeIdentifiers) {
+	std::string code = "start..end";
+	std::vector<Token> tokens = forest::parser::Tokeniser::parse(code, filePath);
+
+	ASSERT_EQ(tokens.size(), 3);
+
+	Token first = tokens[0];
+	EXPECT_EQ(first.mType, TokenType::IDENTIFIER);
+	EXPECT_STREQ(first.mText.c_str(), "start");
+
+	Token second = tokens[1];
+	EXPECT_EQ(second.mType, TokenType::OPERATOR);
+	EXPECT_EQ(second.mSubType, TokenSubType::RANGE);
+	EXPECT_STREQ(second.mText.c_str(), "..");
+
+	Token third = tokens[2];
+	EXPECT_EQ(third.mType, TokenType::IDENTIFIER);
+	EXPECT_STREQ(third.mText.c_str(), "end");
+}
+
 TEST_F(TokeniserTests, TokeniserParseShouldTokeniseNamespace) {
 	std::string code = "ns::function";
 	std::vector<Token> tokens = forest::parser::Tokeniser::parse(code, filePath);

--- a/Source/Tokeniser/Tokeniser.cpp
+++ b/Source/Tokeniser/Tokeniser.cpp
@@ -128,10 +128,11 @@ namespace forest::parser {
 						currentToken.mText.append(2, currChar);
 						endToken(currentToken, tokens);
 					} else if (lastToken.mSubType == TokenSubType::DOT) { // A 2nd dot -> range operator
-						currentToken.mText.append(1, currChar);
+						tokens.pop_back();
+						currentToken.mText.append(2, currChar);
 						currentToken.mType = TokenType::OPERATOR;
 						currentToken.mSubType = TokenSubType::RANGE;
-						currentToken.mStartOffset = start;
+						currentToken.mStartOffset = start - 1;
 						currentToken.mEndOffset = end + 1;
 						endToken(currentToken, tokens);
 					} else if (currentToken.mSubType == TokenSubType::INTEGER_LITERAL) {// Integers can't contain dots, so this must be a decimal number.

--- a/Source/X86_64LinuxYasmCompiler.cpp
+++ b/Source/X86_64LinuxYasmCompiler.cpp
@@ -483,9 +483,11 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					uint32_t localLabelCount = ++labelCount;
 					label = label.append(std::to_string(localLabelCount));
 					recentLoopLabel = label;
-					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", " << ls.mRange.value().mMinimum->mValue.mText << std::endl;
+					printExpression(outfile, p, ls.mRange.value().mMinimum, 0);
+					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", rax" << std::endl;
 					outfile << label << ":" << std::endl;
-					outfile << "\tcmp " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", " << ls.mRange.value().mMaximum->mValue.mText << std::endl;
+					printExpression(outfile, p, ls.mRange.value().mMaximum, 0);
+					outfile << "\tcmp " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", rax" << std::endl;
 					outfile << "\tjne .inside_label" << localLabelCount << std::endl;
 					outfile << "\tjmp .not_label" << localLabelCount << std::endl;
 					outfile << ".inside_label" << localLabelCount << ":" << std::endl;
@@ -493,7 +495,7 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					outfile << ".skip_label" << localLabelCount << ":" << std::endl;
 					outfile << "\t" << moveToRegister("rax", symbolTable[ls.mIterator.value().mName]).str();
 					outfile << "\t" << op << "rax" << std::endl;
-					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", al" << std::endl;
+					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", rax" << std::endl;
 					outfile << "\tjmp .label" << localLabelCount << std::endl;
 					outfile << ".not_label" << localLabelCount << ":" << std::endl;
 				} else {

--- a/Source/X86_64LinuxYasmCompiler.cpp
+++ b/Source/X86_64LinuxYasmCompiler.cpp
@@ -765,6 +765,9 @@ ExpressionPrinted X86_64LinuxYasmCompiler::printExpression(std::ofstream& outfil
 		} else {
 			outfile << "\tcall " << ss.str() << std::endl;
 		}
+		if (nodeType == 1) {
+			outfile << "\tmov rbx, rax; printExpression, nodeType=1, function call" << std::endl;
+		}
 
 		outfile << "\tpop r10" << std::endl;
 		outfile << "\tpop r9" << std::endl;
@@ -930,8 +933,6 @@ ExpressionPrinted X86_64LinuxYasmCompiler::printExpression(std::ofstream& outfil
 		const char* reg = "rbx";//getRegister("b", size);
 		outfile << "\tmov " << reg << ", " << expression->mChildren[1]->mValue.mText << "; printExpression, right int" << std::endl;
 	} else {
-		if (rightPrinted.printed)
-			outfile << "\tmov rbx, rax; printExpression, right else if right printed" << std::endl;
 		rightSize = rightPrinted.size;
 	}
 

--- a/Source/X86_64LinuxYasmCompiler.cpp
+++ b/Source/X86_64LinuxYasmCompiler.cpp
@@ -484,10 +484,11 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					label = label.append(std::to_string(localLabelCount));
 					recentLoopLabel = label;
 					printExpression(outfile, p, ls.mRange.value().mMinimum, 0);
-					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", rax" << std::endl;
+					const char* reg = getRegister("a", size);
+					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", " << reg << std::endl;
 					outfile << label << ":" << std::endl;
 					printExpression(outfile, p, ls.mRange.value().mMaximum, 0);
-					outfile << "\tcmp " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", rax" << std::endl;
+					outfile << "\tcmp " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", " << reg << std::endl;
 					outfile << "\tjne .inside_label" << localLabelCount << std::endl;
 					outfile << "\tjmp .not_label" << localLabelCount << std::endl;
 					outfile << ".inside_label" << localLabelCount << ":" << std::endl;
@@ -495,7 +496,7 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 					outfile << ".skip_label" << localLabelCount << ":" << std::endl;
 					outfile << "\t" << moveToRegister("rax", symbolTable[ls.mIterator.value().mName]).str();
 					outfile << "\t" << op << "rax" << std::endl;
-					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", rax" << std::endl;
+					outfile << "\tmov " << sizes[size] << " " << symbolTable[ls.mIterator.value().mName].location() << ", " << reg << std::endl;
 					outfile << "\tjmp .label" << localLabelCount << std::endl;
 					outfile << ".not_label" << localLabelCount << ":" << std::endl;
 				} else {

--- a/Source/X86_64LinuxYasmCompiler.hpp
+++ b/Source/X86_64LinuxYasmCompiler.hpp
@@ -16,19 +16,21 @@ struct SymbolInfo {
 	int size {};
 	bool isGlobal = false;
 
-	std::string location() const {
+	std::string location(bool dereference = true) const {
 		std::stringstream ss;
+		if (dereference)
+			ss << "[";
 		if (reg == "rbp") {
-			ss << "[" << reg;
+			ss << reg;
 			if (offset > 0)
 				ss << "+" << offset;
 			else if (offset < 0)
 				ss << offset;
-			ss << "]";
-		} else if (isGlobal)
-			ss << "[" << reg << "]";
-		else
+		} else
 			ss << reg;
+
+		if (dereference)
+			ss << "]";
 		return ss.str();
 	}
 };
@@ -41,6 +43,7 @@ struct ExpressionPrinted {
 
 class X86_64LinuxYasmCompiler {
 public:
+	X86_64LinuxYasmCompiler();
 	void compile(fs::path& filePath, const Programme& p, const CompileContext& ctx);
 
 private:
@@ -48,9 +51,11 @@ private:
 	uint32_t ifCount = 0;
 	std::string recentLoopLabel{};
 	std::map<std::string, SymbolInfo> symbolTable;
+	std::map<std::string, uint32_t> syscallTable;
 	void printBody(std::ofstream& outfile, const Programme& p, const Block& block, const std::string& labelName, int* offset);
 	void printLibs(std::ofstream& outfile);
 	void printFunctionCall(std::ofstream& outfile, const Programme& p, const FuncCallStatement& fc);
+	void printSyscall(std::ofstream& outfile, const std::string& syscall);
 	/**
 	 * Will print the expression. The resulting value will be in the a register (rax, eax, ax, al)
 	 */

--- a/Source/X86_64LinuxYasmCompiler.hpp
+++ b/Source/X86_64LinuxYasmCompiler.hpp
@@ -14,6 +14,7 @@ struct SymbolInfo {
 	int offset {};
 	Type type {};
 	int size {};
+	bool isGlobal = false;
 
 	std::string location() const {
 		std::stringstream ss;
@@ -24,7 +25,9 @@ struct SymbolInfo {
 			else if (offset < 0)
 				ss << offset;
 			ss << "]";
-		} else
+		} else if (isGlobal)
+			ss << "[" << reg << "]";
+		else
 			ss << reg;
 		return ss.str();
 	}
@@ -53,7 +56,7 @@ private:
 	 */
 	ExpressionPrinted printExpression(std::ofstream& outfile, const Programme& p, const Expression* expression, uint8_t nodeType);
 	void printConditionalMove(std::ofstream& outfile, int leftSize, int rightSize, const char* instruction);
-	int addToSymbols(int* offset, const Variable& variable, const std::string& reg = "rbp-");
+	int addToSymbols(int* offset, const Variable& variable, const std::string& reg = "rbp-", bool isGlobal = false);
 	std::stringstream moveToRegister(const std::string& reg, const SymbolInfo& symbol);
 	const char* getRegister(const std::string& reg, int size);
 	int getSizeFromNumber(const std::string& text);
@@ -61,6 +64,8 @@ private:
 	const char* getMoveAction(int regSize, int valSize, bool isSigned);
 	int getSizeFromByteSize(size_t byteSize);
 	const char* convertARegSize(int size);
+	const char* getDefineBytes(size_t byteSize);
+	const char* getReserveBytes(size_t byteSize);
 };
 
 


### PR DESCRIPTION
Variables get detected through the `frstconfig` in the directory. Constant variables go into `rodata`, initialised variables go in `data` and uninitialised variables/arrays go into `bss`

It would be nice if I had a way to unit test the compilation step. Through manual testing this seemed to work though