### PR TITLE
Fix: potential bug when EOF during variable parsing

### DIFF
--- a/Source/Parser/Parser.cpp
+++ b/Source/Parser/Parser.cpp
@@ -87,7 +87,7 @@ namespace forest::parser {
 					std::optional<Statement> var = tryParseVariableDeclaration();
 					// Top level variable declaration
 					if (var.has_value()) {
-						if (tokens.begin()->file == mCurrentToken->file || mCurrentToken == mTokensEnd)
+						if (tokens.begin()->file == current->file || mCurrentToken == mTokensEnd)
 							variables.insert(std::make_pair(var.value().variable.value().mName, var.value().variable.value()));
 					}
 				} else {


### PR DESCRIPTION
This PR is because my previous change was not added correctly to the previous PR... I assumed that after a file was already staged, any following change would also be commited. Turns out that's not the case