### PR TITLE
Fix: General bugs and mathematical errors 

### DIFF
--- a/Source/Parser/Parser.cpp
+++ b/Source/Parser/Parser.cpp
@@ -270,13 +270,16 @@ namespace forest::parser {
 				localVars.push_back(variable.mName);
 			} else if (statement.value().mType == Statement_Type::LOOP) {
 				LoopStatement ls = statement.value().loopStatement.value();
-				size_t byteSize = ls.mIterator.value().mType.byteSize;
-				stackMem += byteSize;
-				if (byteSize > biggestAlloc)
-					biggestAlloc = byteSize;
+				if (ls.mIterator.has_value()) {
+					size_t byteSize = ls.mIterator.value().mType.byteSize;
+					stackMem += byteSize;
+					if (byteSize > biggestAlloc)
+						biggestAlloc = byteSize;
 
-				variables.insert({ls.mIterator.value().mName, ls.mIterator.value() });
-				localVars.push_back(ls.mIterator.value().mName);
+					variables.insert({ls.mIterator.value().mName, ls.mIterator.value() });
+					localVars.push_back(ls.mIterator.value().mName);
+				}
+
 			}
 
 			statements.push_back(statement.value());
@@ -746,6 +749,9 @@ namespace forest::parser {
 			Range r = Range { min, max };
 			ls.mRange = r;
 			ls.mIterator = Variable { getTypeFromRange(r), iterator.value().mText, {} };
+		} else {
+			ls.mIterator = std::nullopt;
+			ls.mRange = std::nullopt;
 		}
 		std::optional<Block> body = expectBlock();
 		if (!body.has_value()) {

--- a/Source/Parser/Parser.cpp
+++ b/Source/Parser/Parser.cpp
@@ -296,7 +296,7 @@ namespace forest::parser {
 			variables.erase(name);
 		}
 
-		stackMem += biggestAlloc;
+		stackMem += biggestAlloc * 2;
 		return Block { statements, stackMem, biggestAlloc };
 	}
 
@@ -655,6 +655,10 @@ namespace forest::parser {
 				alias << "str" << literals.size();
 
 				literals.push_back(Literal{alias.str(), expression->mValue.mText, uint32_t(expression->mValue.mText.size())});
+				if (className.value().mText == "stdout" && functionName.value().mText == "writeln") {
+					literals.at(literals.size() - 1).mContent.append("\n");
+					literals.at(literals.size() - 1).mSize += 1;
+				}
 			}
 
 			std::optional<Token> closingParenthesis = expectOperator(")");
@@ -680,13 +684,6 @@ namespace forest::parser {
 			// ^ Commented out because it did parse the function call correctly, it just didn't end with a semi.
 			// We want it to keep giving parser errors for the rest of the code, not try to parse something else.
 			return std::nullopt;
-		}
-
-		if (className.value().mText == "stdout" && functionName.value().mText == "writeln") {
-			if (!literals.empty()) {
-				literals.at(literals.size() - 1).mContent.append("\n");
-				literals.at(literals.size() - 1).mSize += 1;
-			}
 		}
 
 		returnValue.funcCall = fc;

--- a/Source/Tokeniser/Tokeniser.hpp
+++ b/Source/Tokeniser/Tokeniser.hpp
@@ -97,6 +97,7 @@ namespace forest::parser {
 		static std::vector<Token> parse(const std::string& inProgram, const std::string& fileName);
 
 		static void endToken(Token& token, std::vector<Token>& tokens);
+		inline static size_t mLine;
 	};
 
 	std::ostream& operator<<(std::ostream&, const Token&);

--- a/Source/X86_64LinuxYasmCompiler.cpp
+++ b/Source/X86_64LinuxYasmCompiler.cpp
@@ -252,7 +252,6 @@ void X86_64LinuxYasmCompiler::compile(fs::path& filePath, const Programme& p, co
 }
 
 void X86_64LinuxYasmCompiler::printLibs(std::ofstream& outfile) {
-	outfile << "section .text" << std::endl;
 	outfile << "global print_ui64" << std::endl;
 	outfile << "print_ui64:" << std::endl;
 	outfile << "\tpush rbp" << std::endl;

--- a/Source/X86_64LinuxYasmCompiler.cpp
+++ b/Source/X86_64LinuxYasmCompiler.cpp
@@ -651,6 +651,7 @@ void X86_64LinuxYasmCompiler::printBody(std::ofstream& outfile, const Programme&
 						std::string label = ".label";
 						label = label.append(std::to_string(++labelCount));
 						outfile << label << ":" << std::endl;
+						recentLoopLabel = label;
 						printBody(outfile, p, ls.mBody, label, offset, allocs);
 						outfile << "\tjmp .label" << labelCount << std::endl;
 						outfile << ".not_label" << labelCount << ":" << std::endl; // Used for break statements


### PR DESCRIPTION
- `20 - 0` no longer equals 19
- Multiplying 2 16-bit numbers now correctly becomes a 32-bit number
- You can now actually use your function parameters
- Stack memory gets properly de-allocated now (and early returns don't fuck up the return address)
- String literals no longer magically get a newline when they shouldn't have one
- Multiline comments are actual comments now (wow, amazing)
- Fixed SIGFPE on division operations (`/` and `%`)
- Fixed many instances where the compiler would crash because it expected an optional to have a value when it didn't